### PR TITLE
Chapter 4: Correct precise64 base box name

### DIFF
--- a/ch04/playbooks/Vagrantfile
+++ b/ch04/playbooks/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "precise" do |precise|
-    precise.vm.box = "precise64"
+    precise.vm.box = "ubuntu/precise64"
     precise.vm.network "private_network", ip: "192.168.4.12"
   end
 end


### PR DESCRIPTION
vagrant up fails with the following message:

> An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.
>
> Couldn't open file /proj/ansible_book/ansiblebook/ch04/playbooks/precise64
