### PR TITLE
Making dynamic inventory script for Vagrant work for Windows

### DIFF
--- a/ch03/inventory/vagrant.py
+++ b/ch03/inventory/vagrant.py
@@ -21,7 +21,7 @@ def list_running_hosts():
     cmd = "vagrant status --machine-readable"
     status = subprocess.check_output(cmd.split()).rstrip()
     hosts = []
-    for line in status.split('\n'):
+    for line in status.splitlines():
         (_, host, key, value) = line.split(',')[:4]
         if key == 'state' and value == 'running':
             hosts.append(host)


### PR DESCRIPTION
When I was going through the examples on Windows, the `--list` option would not report any hosts even through I had two vagrant hosts running.  The problem was that the `vagrant status --machine-readable` command had carriage returns.  The last column was expected to be `'running'` but it in reality it was `'running\r'`.  I changed the script from using `.strip('\n')` to `.splitlines()` which not only handles carriage returns but discards the last _empty line_.