### PR TITLE
Drop unused private_key_file config ch04

### DIFF
--- a/ch04/playbooks/ansible.cfg
+++ b/ch04/playbooks/ansible.cfg
@@ -1,3 +1,2 @@
 [defaults]
 inventory = hosts
-private_key_file = ~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
Not used, all private key paths are specified in the inventory file.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>