### PR TITLE
chapter09 fixes

### DIFF
--- a/chapter09/playbooks/requirements.txt
+++ b/chapter09/playbooks/requirements.txt
@@ -1,6 +1,7 @@
+filebrowser-safe==1.0.0
 Mezzanine==4.3.1
 gunicorn
 setproctitle
 django-compressor
-psycopg2-binary==2.8.6
+psycopg2-binary
 python-memcached

--- a/chapter09/playbooks/roles/mezzanine/tasks/django.yml
+++ b/chapter09/playbooks/roles/mezzanine/tasks/django.yml
@@ -44,7 +44,7 @@
     src: supervisor.conf.j2
     dest: /etc/supervisor/conf.d/mezzanine.conf
     mode: 0640
-  notify: restart supervisor
+  notify: Restart supervisor
 
 - name: Install poll twitter cron job
   cron:


### PR DESCRIPTION
Changes to chapter09 code/config to get mezzanine provisioning to work:
* Add filebrowser-safe==1.0.0 to requirements.txt, otherwise get pg_config not found error
* Remove 2.8.6 version from psycopg2-binary dependency, otherwise get a postgres UTC setting error
* Rename "restart supervisor" to "Restart supervisor" in django.yml, as named in the handler

Note: I also had to update my Vagrant box to "bento/ubuntu-20.04-arm64" and  database_host to
{{ hostvars.db.ansible_eth1.ipv4.address }}, because I'm on a macOS M1 machine, but obviously not including those changes.