### PR TITLE
Fixes for running Ghost locally with Docker Compose

### DIFF
--- a/chapter13/playbooks/docker-compose.yml
+++ b/chapter13/playbooks/docker-compose.yml
@@ -12,4 +12,6 @@ services:
       - ghost
   ghost:
     image: ghost
+    environment:
+      NODE_ENV: development
 ...

--- a/chapter13/playbooks/ghost.yml
+++ b/chapter13/playbooks/ghost.yml
@@ -3,6 +3,8 @@
 - name: Run Ghost locally
   hosts: localhost
   gather_facts: false
+  vars:
+    ansible_python_interpreter: ../py3/bin/python
   tasks:
 
     - name: Create Nginx image
@@ -14,6 +16,12 @@
         state: present
         force_source: "{{ force_source | default(false) }}"
         tag: "{{ tag | default('v1') }}"
+
+    - name: Create certs directory
+      file:
+        path: "./certs"
+        state: directory
+        mode: 0750
 
     - name: Create certs
       command: >

--- a/chapter13/requirements.txt
+++ b/chapter13/requirements.txt
@@ -1,1 +1,2 @@
+docker==6.1.3
 docker-compose


### PR DESCRIPTION
* Pin docker python lib to 6.3.1 as 7.0.0 is not compatible with [docker_compose module](https://docs.ansible.com/ansible/devel/collections/community/docker/docker_compose_module.html#ansible-collections-community-docker-docker-compose-module)
* Specify Ansible Python Interpreter
* Create certs directory before trying to write keys
