### PR TITLE
Update centos/stream8 to 9 to avoid download "error: 404"

### DIFF
--- a/chapter02/playbooks/config.json
+++ b/chapter02/playbooks/config.json
@@ -56,7 +56,7 @@
         "distro": "centos",
         "family": "redhat",
         "gui": false,
-        "box": "centos/stream8",
+        "box": "centos/stream9",
         "ip_addr": "192.168.56.6",
         "memory": "1024",
         "no_share": false,

--- a/chapter04/Vagrantfile
+++ b/chapter04/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vagrant2.vm.network "forwarded_port", guest: 443, host: 8444
   end
   config.vm.define "vagrant3" do |vagrant3|
-    vagrant3.vm.box = "centos/stream8"
+    vagrant3.vm.box = "centos/stream9"
     vagrant3.vm.network "forwarded_port", guest: 80, host: 8082
     vagrant3.vm.network "forwarded_port", guest: 443, host: 8445
   end

--- a/chapter04/playbooks/vagrant.yml
+++ b/chapter04/playbooks/vagrant.yml
@@ -3,7 +3,7 @@
 - name: Provision a Vagrant machine
   hosts: localhost
   vars:
-    box: "centos/stream8"
+    box: "centos/stream9"
   tasks:
     - name: Create a Vagrantfile
       command: "vagrant init {{ box }}"

--- a/chapter22/playbooks/config.json
+++ b/chapter22/playbooks/config.json
@@ -1,6 +1,6 @@
 [{
         "app_port": "8081",
-        "box": "centos/stream8",
+        "box": "centos/stream9",
         "cpus": 4,
         "distro": "centos",
         "family": "redhat",
@@ -13,7 +13,7 @@
     },
     {
         "app_port": "8080",
-        "box": "centos/stream8",
+        "box": "centos/stream9",
         "cpus": 2,
         "distro": "centos",
         "family": "redhat",
@@ -26,7 +26,7 @@
     },
     {
         "app_port": "3000",
-        "box": "centos/stream8",
+        "box": "centos/stream9",
         "cpus": 2,
         "distro": "centos",
         "family": "redhat",
@@ -39,7 +39,7 @@
     },
     {
         "app_port": "9000",
-        "box": "centos/stream8",
+        "box": "centos/stream9",
         "cpus": 2,
         "distro": "centos",
         "family": "redhat",


### PR DESCRIPTION
I noticed that `vagrant up` for [chapter04/Vagrantfile](https://github.com/ansiblebook/ansiblebook/blame/46a8e8e032f9c529910b58ef69922aa9c74ac1ee/chapter04/Vagrantfile#L18) started failing as of late Nov. 2024:

```
… Downloading: https://vagrantcloud.com/centos/boxes/stream8/versions/20230710.0/providers/virtualbox/unknown/vagrant.box
Download redirected to host: cloud.centos.org
An error occurred while downloading the remote file.
…
The requested URL returned error: 404
```

This patch unblocked me, so I was wondering whether this simple/naïve version bump can be rolled out to all usages?